### PR TITLE
Sync global parameters with contract baseline

### DIFF
--- a/flsim/run_experiment.py
+++ b/flsim/run_experiment.py
@@ -67,6 +67,12 @@ def run(config_path: str, *, rounds:int, nodes:int, malicious_ratio:float, seed:
             seed=42 + r,
         )
 
+        # Ensure the contract's baseline matches the parameters used for training
+        if contract.prev_global is None:
+            contract.prev_global = reference_global
+        else:
+            contract.prev_global = global_params
+
         print(f"Round {r} updates: {len(updates)} clients")
         # FL pipeline using the existing contract (detection/aggregation/etc.)
         
@@ -86,6 +92,8 @@ def run(config_path: str, *, rounds:int, nodes:int, malicious_ratio:float, seed:
         # print("\n", updates)
         # Run the settlement round with the current updates
         res = contract.run_round(r, updates=updates, true_malicious=true_mal)
+        global_params = res["global_params"]
+        contract.prev_global = global_params
         print(f"Round {r} results: {res}")
 
         results.append(res)


### PR DESCRIPTION
## Summary
- keep contract's baseline in sync with parameters used for training
- update global parameters from run_round results and reuse for subsequent rounds

## Testing
- `pytest -q` *(fails: selection size, settlement penalty applied, flame aggregation shape)*

------
https://chatgpt.com/codex/tasks/task_e_68a85fc3c974832fa6a113c00780bdda