### PR TITLE
Align logistic regression metrics with callers

### DIFF
--- a/flsim/model/logreg.py
+++ b/flsim/model/logreg.py
@@ -90,14 +90,20 @@ class LogisticRegression(BaseModel):
         acc = float(np.mean(preds == y)) if N > 0 else float("nan")
         loss, _ = self._batch_grad(X, y)
 
-        nan = "unknown"
-        # Optional val metrics
+        # Optional validation metrics
         if X_val is not None and y_val is not None and y_val.size > 0:
             v_logits = self.predict_logits(X_val)
             v_preds = np.argmax(_softmax(v_logits), axis=1)
             v_acc = float(np.mean(v_preds == y_val))
-            metrics = {"loss": float(loss), "train acc": float(acc), "n": float(N)}
         else:
-            metrics = {"loss": float(loss), "train acc": float(acc), "n": float(N)}
+            v_acc = float("nan")
+
+        metrics = {
+            "loss": float(loss),
+            "acc": float(acc),
+            "train_acc": float(acc),
+            "val_acc": v_acc,
+            "n": float(N),
+        }
         print("logreg: ", metrics)
         return metrics

--- a/tests/test_logreg_metrics.py
+++ b/tests/test_logreg_metrics.py
@@ -1,0 +1,29 @@
+import numpy as np
+from flsim.model.logreg import LogisticRegression
+
+
+def test_logreg_fit_local_returns_consistent_metrics():
+    # Simple dataset where model can achieve perfect accuracy
+    X = np.array([[1.0, 0.0], [0.0, 1.0]])
+    y = np.array([0, 1])
+    X_val = X.copy()
+    y_val = y.copy()
+
+    model = LogisticRegression(input_dim=2, num_classes=2)
+    model.init_parameters()
+
+    metrics = model.fit_local(
+        X,
+        y,
+        epochs=1,
+        batch_size=1,
+        lr=0.1,
+        shuffle=False,
+        rng=np.random.default_rng(0),
+        X_val=X_val,
+        y_val=y_val,
+    )
+
+    assert metrics["acc"] == metrics["train_acc"]
+    assert set(["loss", "acc", "train_acc", "val_acc", "n"]).issubset(metrics)
+    assert not np.isnan(metrics["val_acc"])


### PR DESCRIPTION
## Summary
- Ensure logistic regression's `fit_local` returns `acc`, `train_acc`, and `val_acc` consistently
- Add regression test checking metric keys and validation accuracy

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a86849c664832fa9eccc7627837e4c