### PR TITLE
Handle missing prev_global in run_experiment

### DIFF
--- a/flsim/run_experiment.py
+++ b/flsim/run_experiment.py
@@ -91,10 +91,9 @@ def run(config_path: str, *, rounds:int, nodes:int, malicious_ratio:float, seed:
             seed=42 + r,
         )
         # Ensure the contract's baseline matches the parameters used for training
-        if contract.prev_global is None:
-            contract.prev_global = reference_global
-        else:
-            contract.prev_global = global_params
+        prev = getattr(contract, "prev_global", None)
+        contract.prev_global = reference_global if prev is None else global_params
+        global_params = reference_global
 
         logger.info(f"Round {r} updates: {len(updates)} clients")
 


### PR DESCRIPTION
## Summary
- avoid AttributeError when contract lacks `prev_global`
- update global parameter state each round

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a86a61ae20832fb06379b6cea582d9