### PR TITLE
Switch to model_sift detector API

### DIFF
--- a/flsim/incentive/settlement.py
+++ b/flsim/incentive/settlement.py
@@ -15,7 +15,8 @@ class SettlementEnginePlans:
 
     def run(self, round_idx: int, nodes: Dict[int, NodeState], contributions: Dict[int, float], features: Dict[int, Dict[str, float]],
             pre_rewards: Dict[int, float], detector, reward_policy, penalty_policy, reputation_policy) -> Dict[str, Any]:
-        detected = detector.detect(features, contributions)
+        detected_res = detector.model_sift(round_idx, features, contributions, [], [])
+        detected = detected_res if isinstance(detected_res, dict) else {}
 
         plans: Dict[str, Any] = {
             "apply_penalties": {},

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -24,7 +24,7 @@ def test_settlement_penalty_applied():
         c.set_contribution(nid, 0.0 if nid == 1 else 0.9)
         c.credit_reward(nid, 10.0)
     # Force detection to mark node 1 as malicious
-    c.detector.detect = lambda feats, scores: {1: True}
+    c.detector.model_sift = lambda *args, **kwargs: {1: True}
     res = c.run_round(0, updates=None, true_malicious={1})
     assert isinstance(res, dict)
 


### PR DESCRIPTION
## Summary
- use `model_sift` instead of `detect` within settlement engine
- adapt tests to patch `model_sift`

## Testing
- `pip install torch --quiet` *(fails: Cannot connect to proxy)*
- `pytest tests/test_contracts.py::test_settlement_penalty_applied -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68ab35245ad0832f954eda485b7db5cf