### PR TITLE
Fix penalty node lookup and ensure node 0 counted

### DIFF
--- a/flsim/contracts/composed.py
+++ b/flsim/contracts/composed.py
@@ -104,7 +104,7 @@ class ComposedContract:
         return float(new_rep)
 
     def apply_penalty(self, node_id: int, *, stake_mul: float | None = None, rep_mul: float | None = None) -> None:
-        node = self.nodes.get(int(node_id)-1)
+        node = self.nodes.get(int(node_id))
         if node is None:
             return
         stake_mul = float(stake_mul) if stake_mul is not None else (

--- a/flsim/incentive/__init__.py
+++ b/flsim/incentive/__init__.py
@@ -1,2 +1,7 @@
 from . import selection, settlement, contribution, reward, penalty, reputation  # noqa: F401
-from .detection import flame as detection_flame  # noqa: F401
+
+# Optional detection module; gracefully handle missing dependencies like torch
+try:  # pragma: no cover - import side-effect
+    from .detection import flame as detection_flame  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - torch or other deps missing
+    detection_flame = None

--- a/tests/test_node_zero.py
+++ b/tests/test_node_zero.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from flsim.contracts.composed import ComposedContract, ContractConfig
+
+
+def test_node_zero_incentive_flow():
+    """Ensure node 0 participates fully in incentive mechanisms."""
+    c = ComposedContract(ContractConfig(committee_size=1, settlement="plans_engine"))
+
+    # Register nodes including node 0
+    c.register_node(0, stake=100.0, reputation=50.0)
+    c.register_node(1, stake=100.0, reputation=50.0)
+
+    # Contribution tracking should record node 0
+    c.set_contribution(0, 0.8)
+    assert c.contributions.get(0) == 0.8
+
+    # Reward accounting should credit node 0
+    c.credit_reward(0, amount=10.0)
+    assert c.rewards.get(0) == 10.0
+
+    # Reputation updates should modify node 0's reputation
+    prev_rep = c.nodes[0].reputation
+    c.update_reputation(0, contribution=0.8, current_round=1)
+    assert c.nodes[0].reputation != prev_rep
+
+    # Penalty application should reduce stake and reputation of node 0
+    prev_stake = c.nodes[0].stake
+    prev_rep = c.nodes[0].reputation
+    c.apply_penalty(0, stake_mul=0.9, rep_mul=0.9)
+    assert np.isclose(c.nodes[0].stake, prev_stake * 0.9)
+    assert np.isclose(c.nodes[0].reputation, prev_rep * 0.9)
+


### PR DESCRIPTION
## Summary
- fix off-by-one bug in `ComposedContract.apply_penalty` so node IDs are looked up directly
- gracefully skip optional detection imports when dependencies like torch are missing
- add regression tests including coverage for node 0 and adjust existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8a84f3a4832fa540dc1452605285