### PR TITLE
Enhance node state tracking and committee logic

### DIFF
--- a/flsim/core/types.py
+++ b/flsim/core/types.py
@@ -11,6 +11,7 @@ class NodeState:
     cooldown: float = 0.0
     contrib_history: List[float] = field(default_factory=list)
     participation: int = 0
+    committee_history: List[int] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 @dataclass


### PR DESCRIPTION
## Summary
- Track committee participation history directly within `NodeState`
- Update committee selection to maintain cooldowns and log per-node history
- Expose full node state after each round and add tests for these updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac25d344c8832f88090fb3317dfc2d