### PR TITLE
Add round-level statistical analysis utilities

### DIFF
--- a/flsim/contracts/composed.py
+++ b/flsim/contracts/composed.py
@@ -178,6 +178,7 @@ class ComposedContract:
             self.rewards,
             # self.detected,
             detected_ids,
+            self.committee,
             self.reward,
             self.penalty,
             self.reputation,

--- a/flsim/metrics.py
+++ b/flsim/metrics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Dict, Set, List
+from typing import Dict, Set, List, Any
 
 @dataclass
 class DetectionMetrics:
@@ -30,3 +30,57 @@ class DetectionMetrics:
                 "tp": tp, "fp": fp, "fn": fn
             })
         return out
+
+
+def compute_round_statistics(results: List[Dict[str, Any]], detection_summary: List[Dict[str, Any]]):
+    """Collect per-round statistics for accuracy, detection rate and balances.
+
+    Parameters
+    ----------
+    results: List[Dict[str, Any]]
+        Per-round outputs returned from the contract (each containing at least
+        ``round`` and ``balances`` and optionally ``metrics`` with an ``acc``).
+    detection_summary: List[Dict[str, Any]]
+        Output from :meth:`DetectionMetrics.summary` describing detection
+        performance each round.
+
+    Returns
+    -------
+    Dict[str, List]
+        Dictionary with three keys capturing the requested statistics:
+
+        ``accuracy_per_round``
+            List of ``(round, acc)`` tuples if accuracy data is present.
+        ``detection_rate_per_round``
+            List of ``(round, recall)`` tuples where recall acts as the
+            malicious detection rate.
+        ``balances_per_round``
+            List of ``(round, balances_dict)`` for the balances among nodes.
+    """
+
+    acc_curve: List[tuple[int, float]] = []
+    detection_rates: List[tuple[int, float]] = []
+    balances_over_time: List[tuple[int, Dict[int, float]]] = []
+
+    det_by_round = {d.get("round"): d for d in detection_summary}
+
+    for res in results:
+        r = int(res.get("round", 0))
+
+        metrics = res.get("metrics") or {}
+        acc = metrics.get("acc")
+        if acc is not None:
+            acc_curve.append((r, float(acc)))
+
+        det = det_by_round.get(r)
+        if det is not None:
+            detection_rates.append((r, float(det.get("recall", 0.0))))
+
+        bal = {int(k): float(v) for k, v in (res.get("balances") or {}).items()}
+        balances_over_time.append((r, bal))
+
+    return {
+        "accuracy_per_round": acc_curve,
+        "detection_rate_per_round": detection_rates,
+        "balances_per_round": balances_over_time,
+    }

--- a/flsim/run_malicious_ground_truth.py
+++ b/flsim/run_malicious_ground_truth.py
@@ -160,7 +160,7 @@ def main():
             r, detected_ids=malicious, updates=updates, true_malicious=true_mal
         )  # malicious ground-truth here
         print(f"res: {result}")
-        
+
         # ---------------- evaluate global model -----------------
         # mG = evaluate_global_params(args.model, result["global_params"], X_eval, y_eval)
         # print(f"GLOBAL: acc={mG['acc']:.4f}, loss={mG['loss']:.4f}")
@@ -168,11 +168,9 @@ def main():
         eval_metrics2 = evaluate_global_params(args.model, global_params2,
                                          X_eval, y_eval)
         print(f"[Eval] Global after round {r}: acc={eval_metrics2['acc']:.4f}, loss={eval_metrics2['loss']:.4f}")
-        
-        # exit()
-        # The contract stores the new global in result["metrics"] if configured; otherwise,
-        # res = c.run_round(r, updates=updates, true_malicious=true_mal)
-        # print(f"Results: {result}")
+
+        # Include evaluation metrics in the round results for downstream analysis
+        result["metrics"] = eval_metrics2
         results.append(result)
 
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -72,3 +72,27 @@ def test_nodestate_updates():
     # committee history for selected nodes
     for nid in out["committee"]:
         assert 0 in c.nodes[nid].committee_history
+
+
+def test_committee_bonus_applied_in_settlement():
+    c = ComposedContract(ContractConfig(committee_size=1, settlement="plans_engine"))
+    for nid in (1, 2):
+        c.register_node(nid, stake=100.0, reputation=50.0)
+        c.nodes[nid].contrib_history.append(1.0)
+    committee = [1]
+    c.committee = committee
+    plans = c.settlement.run(
+        0,
+        c.nodes,
+        {},
+        {},
+        {},
+        set(),
+        committee,
+        c.reward,
+        c.penalty,
+        c.reputation,
+    )
+    r1 = plans["computed_rewards_next"][1]
+    r2 = plans["computed_rewards_next"][2]
+    assert r1 > r2

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,21 @@
+import pytest
+from flsim.metrics import compute_round_statistics
+
+
+def test_compute_round_statistics():
+    results = [
+        {"round": 1, "metrics": {"acc": 0.7}, "balances": {1: 5.0, 2: 3.0}},
+        {"round": 2, "metrics": {"acc": 0.8}, "balances": {1: 8.0, 2: 5.0}},
+    ]
+    detection_summary = [
+        {"round": 1, "recall": 0.5},
+        {"round": 2, "recall": 1.0},
+    ]
+
+    stats = compute_round_statistics(results, detection_summary)
+    assert stats["accuracy_per_round"] == [(1, 0.7), (2, 0.8)]
+    assert stats["detection_rate_per_round"] == [(1, 0.5), (2, 1.0)]
+    assert stats["balances_per_round"] == [
+        (1, {1: 5.0, 2: 3.0}),
+        (2, {1: 8.0, 2: 5.0}),
+    ]


### PR DESCRIPTION
## Summary
- add `compute_round_statistics` to collate accuracy, detection recall and node balance per round
- log evaluation metrics in malicious ground truth runner to support analysis
- cover analysis helper with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca060645c832f894cf80e468386dc