### PR TITLE
Ensure per-round reward overwriting

### DIFF
--- a/flsim/contracts/composed.py
+++ b/flsim/contracts/composed.py
@@ -90,7 +90,7 @@ class ComposedContract:
         reward_amt = self.reward.compute(node, self.nodes, in_committee=in_committee)
         if amount is not None:
             reward_amt = float(amount)
-        self.rewards[int(node_id)] = self.rewards.get(int(node_id), 0.0) + float(reward_amt)
+        self.rewards[int(node_id)] = float(reward_amt)
         # print(f"node {node_id}'s credit reward amount: {reward_amt}, {node}")
         return float(reward_amt)
 


### PR DESCRIPTION
## Summary
- Prevent reward accumulation by storing only the most recent reward for each node

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad80020468832fb4eae680a03f3e4f