### PR TITLE
Add baseline experiment configs

### DIFF
--- a/configs/exp_fedavg.yaml
+++ b/configs/exp_fedavg.yaml
@@ -1,0 +1,41 @@
+committee_size: 0
+committee_cooldown: 0
+rep_exponent: 0.0
+
+detection:
+  name: flame
+  params:
+    min_points: 4
+    min_cluster_frac: 0.2
+    dbscan_eps: 0.3
+    detect_score_thresh: 0.1
+
+aggregation:
+  name: fedavg
+
+selection:
+  name: stratified_softmax
+
+settlement:
+  name: plans_engine
+  params:
+    warmup_rounds: 0
+
+reward:
+  name: default
+  params:
+    base_reward: 0.0
+    hist_decay: 0.0
+    stake_weight: 0.0
+
+penalty:
+  name: default
+  params:
+    stake_penalty_factor: 0.0
+    rep_penalty_factor: 0.0
+
+reputation:
+  name: default
+  params:
+    X_c: 0.0
+    X_s: 0.0

--- a/configs/exp_flame.yaml
+++ b/configs/exp_flame.yaml
@@ -1,0 +1,46 @@
+committee_size: 0
+committee_cooldown: 0
+rep_exponent: 0.0
+
+detection:
+  name: flame
+  params:
+    min_points: 4
+    min_cluster_frac: 0.2
+    dbscan_eps: 0.3
+    detect_score_thresh: 0.1
+
+aggregation:
+  name: flame_agg
+  params:
+    percentile: 0.9
+    epsilon: 1e6
+    delta: 1e-4
+    use_clipping: true
+
+selection:
+  name: stratified_softmax
+
+settlement:
+  name: plans_engine
+  params:
+    warmup_rounds: 0
+
+reward:
+  name: default
+  params:
+    base_reward: 0.0
+    hist_decay: 0.0
+    stake_weight: 0.0
+
+penalty:
+  name: default
+  params:
+    stake_penalty_factor: 0.0
+    rep_penalty_factor: 0.0
+
+reputation:
+  name: default
+  params:
+    X_c: 0.0
+    X_s: 0.0

--- a/configs/exp_plain_fedavg.yaml
+++ b/configs/exp_plain_fedavg.yaml
@@ -1,0 +1,33 @@
+committee_size: 0
+committee_cooldown: 0
+rep_exponent: 0.0
+
+aggregation:
+  name: fedavg
+
+selection:
+  name: stratified_softmax
+
+settlement:
+  name: plans_engine
+  params:
+    warmup_rounds: 0
+
+reward:
+  name: default
+  params:
+    base_reward: 0.0
+    hist_decay: 0.0
+    stake_weight: 0.0
+
+penalty:
+  name: default
+  params:
+    stake_penalty_factor: 0.0
+    rep_penalty_factor: 0.0
+
+reputation:
+  name: default
+  params:
+    X_c: 0.0
+    X_s: 0.0


### PR DESCRIPTION
## Summary
- add plain FedAvg experiment config with no detection or incentive mechanisms
- add FedAvg baseline with FLAME detection
- add FLAME baseline with detection and aggregation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b7dce0a8832f89293cdabef983bc