### PR TITLE
Disable incentive modules for FLAME experiment

### DIFF
--- a/configs/exp_flame.yaml
+++ b/configs/exp_flame.yaml
@@ -3,8 +3,8 @@ detection:
   name: flame
 aggregation:
   name: flame_agg       # FLAME aggregation
-selection: null
-reward: null
-penalty: null
-reputation: null
-settlement: null
+selection: none
+reward: none
+penalty: none
+reputation: none
+settlement: none

--- a/flsim/incentive/penalty.py
+++ b/flsim/incentive/penalty.py
@@ -19,3 +19,11 @@ class DefaultPenalty:
 @PENALTY.register("ours")
 class OursPenalty(DefaultPenalty):
     pass
+
+
+@PENALTY.register("none")
+class NoPenalty:
+    """Penalty policy that leaves stake and reputation untouched."""
+
+    def __init__(self, params: PenaltyParams | None = None, **kwargs) -> None:  # noqa: D401
+        self.p = PenaltyParams(stake_penalty_factor=0.0, rep_penalty_factor=0.0)

--- a/flsim/incentive/reputation.py
+++ b/flsim/incentive/reputation.py
@@ -47,3 +47,14 @@ class DefaultReputation:
 @REPUTATION.register("ours")
 class OursReputation(DefaultReputation):
     pass
+
+
+@REPUTATION.register("none")
+class NoReputation:
+    """Reputation policy that performs no updates."""
+
+    def __init__(self, params: ReputationParams | None = None, **kwargs) -> None:  # noqa: D401
+        self.p = params or ReputationParams(**kwargs) if kwargs else (params or ReputationParams())
+
+    def update(self, node: NodeState, contribution: float, *, current_round: int) -> float:
+        return float(node.reputation)

--- a/flsim/incentive/reward.py
+++ b/flsim/incentive/reward.py
@@ -86,3 +86,21 @@ class DefaultReward:
         print(f"reward computed: {reward}, committee bonus: {committee_bonus}, total contribution: {node.contrib_history} \n")
         return float(max(reward, 0.0))
 
+
+@REWARD.register("none")
+class NoReward:
+    """No-op reward policy used for experiments without incentives."""
+
+    def __init__(self, params: RewardParams | None = None, **kwargs) -> None:  # noqa: D401
+        self.p = params or RewardParams(**kwargs) if kwargs else (params or RewardParams())
+
+    def compute(
+        self,
+        node: NodeState,
+        nodes: Dict[int, NodeState],
+        *,
+        in_committee: bool = False,
+    ) -> float:
+        """Return zero reward regardless of inputs."""
+        return 0.0
+

--- a/flsim/incentive/selection.py
+++ b/flsim/incentive/selection.py
@@ -61,3 +61,14 @@ class StratifiedSoftmaxSelector:
             pool = [n for n in ordered if cooldowns.get(n.node_id, 0.0) <= 0.0 and n.node_id not in chosen]
             selected.extend([n.node_id for n in pool[:need]])
         return selected[: self.p.committee_size]
+
+
+@SELECTION.register("none")
+class NoSelection:
+    """Selector that always returns an empty committee."""
+
+    def __init__(self, params: SelectionParams | None = None, **kwargs) -> None:  # noqa: D401
+        pass
+
+    def select(self, nodes: Dict[int, NodeState], cooldowns: Dict[int, float]) -> List[int]:
+        return []

--- a/flsim/incentive/settlement.py
+++ b/flsim/incentive/settlement.py
@@ -102,3 +102,26 @@ class SettlementEnginePlans:
         }
         # print(f"Plans: {plans}")
         return plans
+
+
+@SETTLEMENT.register("none")
+class NoSettlement:
+    """Settlement engine that performs no actions."""
+
+    def __init__(self, params: SettlementParams | None = None, **kwargs) -> None:  # noqa: D401
+        pass
+
+    def run(
+        self,
+        round_idx: int,
+        nodes: Dict[int, NodeState],
+        contributions: Dict[int, float],
+        features: Dict[int, Dict[str, float]],
+        pre_rewards: Dict[int, float],
+        detected,
+        committee: Sequence[int],
+        reward_policy,
+        penalty_policy,
+        reputation_policy,
+    ) -> Dict[str, Any]:
+        return {}

--- a/flsim/run_experiment_flame.py
+++ b/flsim/run_experiment_flame.py
@@ -48,16 +48,10 @@ def main():
     log_fields = [
         "round",
         "node_id",
-        "stake",
-        "reputation",
         "train_acc",
         "train_loss",
         "val_acc",
         "val_loss",
-        "reward",
-        "stake_penalty",
-        "rep_penalty",
-        "is_committee",
         "is_malicious",
         "detected",
     ]
@@ -67,7 +61,7 @@ def main():
 
     # ---------- Register nodes with initial stake and reputation ----------
     for nid in range(0, nodes):
-        contract.register_node(nid, stake=100.0, reputation=50.0)
+        contract.register_node(nid, stake=0.0, reputation=0.0)
     
 
     # ---------- Load client partitions (X, y) -----------
@@ -199,35 +193,20 @@ def main():
         results.append(result)
         # print(f"Round {r} result:", result)
 
-        plans = result.get("plans", {})
-        rewards_map = plans.get("credit_rewards", {})
-        penalties_map = plans.get("apply_penalties", {})
-        committee_set = set(result.get("committee", []))
         detected_set = set(result.get("detected", []))
         truth_set = set(result.get("truth", []))
 
         for nid, state in result["node_states"].items():
             train_m = train_metrics_map.get(nid, {})
             eval_m = eval_metrics_map.get(nid, {})
-            pen = penalties_map.get(nid, {})
             writer.writerow(
                 {
                     "round": r,
                     "node_id": nid,
-                    "stake": state["stake"],
-                    "reputation": state["reputation"],
                     "train_acc": train_m.get("acc", float("nan")),
                     "train_loss": train_m.get("loss", float("nan")),
                     "val_acc": eval_m.get("acc", float("nan")),
                     "val_loss": eval_m.get("loss", float("nan")),
-                    "reward": rewards_map.get(nid, 0.0),
-                    "stake_penalty": pen.get("stake_mul", 0.0)
-                    if nid in penalties_map
-                    else 0.0,
-                    "rep_penalty": pen.get("rep_mul", 0.0)
-                    if nid in penalties_map
-                    else 0.0,
-                    "is_committee": int(nid in committee_set),
                     "is_malicious": int(nid in truth_set),
                     "detected": int(nid in detected_set),
                 }


### PR DESCRIPTION
## Summary
- add no-op reward, penalty, reputation, selection and settlement strategies
- strip staking and incentive logging from FLAME experiment runner
- configure FLAME experiment to avoid committee selection and incentives

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4053dc840832fbda9f11f15b3a5ef