### PR TITLE
Add no-op incentive strategies and simplify FLAME experiment

### DIFF
--- a/configs/exp_base.yaml
+++ b/configs/exp_base.yaml
@@ -1,8 +1,13 @@
 # configs/exp_fedavg.yaml
 aggregation:
   name: fedavg         # FedAvg implementation
-selection: null         # include every client, no committee
-reward: null            # disable reward/penalty/reputation modules
-penalty: null
-reputation: null
-settlement: null
+selection:
+  name: none         # include every client, no committee
+reward:
+  name: none            # disable reward/penalty/reputation modules
+penalty:
+  name: none
+reputation:
+  name: none
+settlement:
+  name: none

--- a/configs/exp_flame.yaml
+++ b/configs/exp_flame.yaml
@@ -3,8 +3,13 @@ detection:
   name: flame
 aggregation:
   name: flame_agg       # FLAME aggregation
-selection: null
-reward: null
-penalty: null
-reputation: null
-settlement: null
+selection:
+  name: none
+reward:
+  name: none
+penalty:
+  name: none
+reputation:
+  name: none
+settlement:
+  name: none

--- a/configs/exp_ours_zero.yaml
+++ b/configs/exp_ours_zero.yaml
@@ -19,38 +19,16 @@ aggregation:
     use_noise: False
 
 selection:
-  name: null
-  params:
-    committee_size: 0
-    rep_exponent: 0
-    cooldown: 0
-    num_strata: 0
+  name: none
 
 settlement:
-  name: plans_engine
-  params:
-    warmup_rounds: 1
+  name: none
 
 reward:
-  name: null
-  params:
-    base_reward: 0
-    hist_decay: 0.
-    stake_weight: 0.
+  name: none
 
 penalty:
-  name: null
-  params:
-    stake_penalty_factor: 0.
-    rep_penalty_factor: 0.
+  name: none
 
 reputation:
-  name: null
-  params:
-    X_c: 0.0
-    X_s: 0.0
-    rep_cap_early: 0.0
-    rep_cap_late: 0.0
-    rep_cap_round: 0
-    contrib_base: 0.0
-    contrib_thre: 0.0
+  name: none

--- a/flsim/contracts/composed_ours.py
+++ b/flsim/contracts/composed_ours.py
@@ -55,8 +55,11 @@ class ComposedContract:
         self.cooldowns: Dict[int, float] = {}
         self.metrics = DetectionMetrics()
 
-    def register_node(self, node_id: int, *, stake: float, reputation: float):
-        self.nodes[node_id] = NodeState(node_id=node_id, stake=float(stake), reputation=float(reputation))
+    def register_node(self, node_id: int, *, stake: float = 0.0, reputation: float = 0.0):
+        """Register a node with optional initial stake and reputation."""
+        self.nodes[node_id] = NodeState(
+            node_id=node_id, stake=float(stake), reputation=float(reputation)
+        )
         self.cooldowns.setdefault(node_id, 0.0)
 
     def set_features(self, node_id: int, **feats: Any):

--- a/flsim/incentive/penalty.py
+++ b/flsim/incentive/penalty.py
@@ -11,3 +11,12 @@ class PenaltyParams:
 class DefaultPenalty:
     def __init__(self, params: PenaltyParams | None = None, **kwargs) -> None:
         self.p = params or PenaltyParams(**kwargs) if kwargs else (params or PenaltyParams())
+
+
+@PENALTY.register("none")
+class NoOpPenalty:
+    """Penalty strategy that leaves stake and reputation untouched."""
+
+    def __init__(self, params: PenaltyParams | None = None, **kwargs) -> None:  # pragma: no cover
+        # Zero multipliers so that ``apply_penalty`` in the contract has no effect
+        self.p = PenaltyParams(stake_penalty_factor=0.0, rep_penalty_factor=0.0)

--- a/flsim/incentive/reputation.py
+++ b/flsim/incentive/reputation.py
@@ -42,36 +42,12 @@ class DefaultReputation:
         return new_rep
 
 
-        """
-        Robust reputation update system
-        
-        Parameters:
-            node (Node): The node whose reputation is being updated.
-            contribution (float): The contribution value from the node.
-            
-        Returns:
-            new_rep (float): The updated reputation value for the node
-        """
-        # Dynamic decay
-        age_factor = 1 - 1/(1 + node.participation/100)
-        delta = 0.88 + 0.07 * age_factor
-        
-        # Contribution quality
-        contrib_base = 0
-        contrib_thre = 10
-        contrib_quality = sigmoid((contribution-contrib_base)/(contrib_thre - contrib_base))
-        
-        # Stability evaluation
-        if len(node.contrib_history) >= 5:
-            stability = 1 - np.std(node.contrib_history[-5:])/5
-        else:
-            stability = 0.8
-        
-        # New reputation calculation 
-        new_rep = (node.reputation * delta + 
-                   contrib_quality * self.X_c + 
-                   stability * self.X_s)
-        
-        # Dynamic cap
-        rep_cap = 500 if self.current_round > 50 else 300
-        return np.clip(new_rep, 0, rep_cap)
+@REPUTATION.register("none")
+class NoOpReputation:
+    """Reputation strategy that keeps reputations constant."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
+        pass
+
+    def update(self, node: NodeState, contribution: float, *, current_round: int) -> float:
+        return float(node.reputation)

--- a/flsim/incentive/reward.py
+++ b/flsim/incentive/reward.py
@@ -86,3 +86,21 @@ class DefaultReward:
         print(f"reward computed: {reward}, committee bonus: {committee_bonus}, total contribution: {node.contrib_history} \n")
         return float(max(reward, 0.0))
 
+
+@REWARD.register("none")
+class NoOpReward:
+    """Reward strategy that always returns zero."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
+        pass
+
+    def compute(
+        self,
+        node: NodeState,  # noqa: D401 - interface compatibility
+        nodes: Dict[int, NodeState],
+        *,
+        in_committee: bool = False,
+    ) -> float:
+        """Return zero reward regardless of inputs."""
+        return 0.0
+

--- a/flsim/incentive/selection.py
+++ b/flsim/incentive/selection.py
@@ -61,3 +61,14 @@ class StratifiedSoftmaxSelector:
             pool = [n for n in ordered if cooldowns.get(n.node_id, 0.0) <= 0.0 and n.node_id not in chosen]
             selected.extend([n.node_id for n in pool[:need]])
         return selected[: self.p.committee_size]
+
+
+@SELECTION.register("none")
+class NoOpSelection:
+    """Selection strategy that never chooses a committee."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover
+        pass
+
+    def select(self, nodes: Dict[int, NodeState], cooldowns: Dict[int, float]) -> List[int]:
+        return []

--- a/flsim/incentive/settlement.py
+++ b/flsim/incentive/settlement.py
@@ -102,3 +102,36 @@ class SettlementEnginePlans:
         }
         # print(f"Plans: {plans}")
         return plans
+
+
+@SETTLEMENT.register("none")
+class NoOpSettlement:
+    """Settlement strategy that performs no incentives or penalties."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
+        pass
+
+    def run(
+        self,
+        round_idx: int,
+        nodes: Dict[int, NodeState],
+        contributions: Dict[int, float],
+        features: Dict[int, Dict[str, float]],
+        pre_rewards: Dict[int, float],
+        detected: Dict[int, bool],
+        committee,
+        reward_policy,
+        penalty_policy,
+        reputation_policy,
+    ) -> Dict[str, Any]:
+        # Only propagate participation and contribution history; everything else stays unchanged
+        plans: Dict[str, Any] = {
+            "apply_penalties": {},
+            "credit_rewards": {},
+            "set_reputations": {},
+            "note_participation": set(contributions.keys()),
+            "append_contrib": {nid: float(contributions.get(nid, 0.0)) for nid in nodes},
+            "detected": detected,
+            "computed_rewards_next": {nid: 0.0 for nid in nodes},
+        }
+        return plans


### PR DESCRIPTION
## Summary
- add `none` implementations for reward, penalty, reputation, selection and settlement
- allow registering nodes without stake or reputation and trim FLAME experiment logging
- configure experiments to use new no-op strategies by default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b40848ef28832f8651f73bc8c3bc8a