### PR TITLE
Map chembl_aqsol alias and ensure node cooldown tracking

### DIFF
--- a/flsim/contracts/composed_ours.py
+++ b/flsim/contracts/composed_ours.py
@@ -60,6 +60,9 @@ class ComposedContract:
         self.nodes[node_id] = NodeState(
             node_id=node_id, stake=float(stake), reputation=float(reputation)
         )
+        # Track cooldown for all registered nodes to avoid KeyError during
+        # access, even if a node has not yet been selected for the committee.
+        self.cooldowns.setdefault(int(node_id), 0.0)
 
     def set_features(self, node_id: int, **feats: Any):
         out = {}

--- a/flsim/data/flower.py
+++ b/flsim/data/flower.py
@@ -16,6 +16,13 @@ except Exception:  # pragma: no cover - dependency may be missing
 # Heuristic list of common label field names; extend as needed for specific datasets
 _LABEL_CANDIDATES = ["label", "labels", "target", "class", "y", "logS"]
 
+# Map shorthand dataset names to their canonical identifiers on the Hugging
+# Face hub.  This allows callers to simply request "chembl_aqsol" without
+# specifying the full owner/name pair required by ``flwr-datasets``.
+_DATASET_ALIASES = {
+    "chembl_aqsol": "jiahborcn/chembl_aqsol",
+}
+
 def _find_label_column(ds) -> str:
     cols = set(ds.column_names)
     for c in _LABEL_CANDIDATES:
@@ -33,6 +40,7 @@ def _num_classes_from_features(ds, label_col: str) -> Optional[int]:
     return None
 
 def load_flower_partitions(dataset: str, num_clients: int, *, iid: bool = True, alpha: float = 0.5, split: str = "train", seed: int = 42):
+    dataset = _DATASET_ALIASES.get(dataset, dataset)
     if FederatedDataset is None:
         raise ImportError("flwr-datasets is not installed. Run: pip install flwr-datasets datasets pillow")
     if iid:
@@ -132,6 +140,7 @@ def load_flower_arrays(
         "none": disable normalization (the `normalize` flag must also be True to enable any normalization).
       - If `max_per_client` is set, each client's data is truncated deterministically.
     """
+    dataset = _DATASET_ALIASES.get(dataset, dataset)
     try:
         from flwr_datasets import FederatedDataset
         from flwr_datasets.partitioner import IidPartitioner, DirichletPartitioner


### PR DESCRIPTION
## Summary
- Map shorthand `chembl_aqsol` dataset name to its full HuggingFace identifier for Flower data loading
- Initialize cooldowns for all registered nodes to prevent KeyErrors in contract logic

## Testing
- `python flsim/run_experiment_ours.py --config configs/exp_ours.yaml --model mlp --dataset chembl_aqsol --mal-behavior scale` *(fails: flwr-datasets is not installed)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76163ddbc832f973918cd2684aa03